### PR TITLE
[ build ] Add custom build hooks to .ipkg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr
 /Idris2JupyterVega/Idris2JupyterVega/VegaLite/*.json
 
 /build

--- a/Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr
+++ b/Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr
@@ -1,0 +1,1 @@
+module Idris2JupyterVega.VegaLite.V5

--- a/idris2-jupyter-vega.ipkg
+++ b/idris2-jupyter-vega.ipkg
@@ -4,6 +4,11 @@ sourcedir = "Idris2JupyterVega"
 
 depends = contrib, python, jupyter
 
+-- script to run before building
+prebuild = "bash v5.sh"
+
+postbuild = "bash restore.sh"
+
 modules =
     Idris2JupyterVega,
     Idris2JupyterVega.VegaLite,

--- a/restore.sh
+++ b/restore.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git restore Idris2JupyterVega/VegaLite/V5.idr
+git restore Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm Idris2JupyterVega/VegaLite/V5.idr

--- a/restore.sh
+++ b/restore.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm Idris2JupyterVega/VegaLite/V5.idr
+git restore Idris2JupyterVega/VegaLite/V5.idr

--- a/v5.sh
+++ b/v5.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+APP=$(pack app-path json-schema)
+
+wget https://vega.github.io/schema/vega-lite/v5.json
+$APP --module-name Idris2JupyterVega.VegaLite.V5 --schema-name VegaLite --json-casts v5.json
+mv v5.idr Idris2JupyterVega/VegaLite/V5.idr
+rm v5.json

--- a/v5.sh
+++ b/v5.sh
@@ -4,5 +4,5 @@ APP=$(pack app-path json-schema)
 
 wget https://vega.github.io/schema/vega-lite/v5.json
 $APP --module-name Idris2JupyterVega.VegaLite.V5 --schema-name VegaLite --json-casts v5.json
-mv v5.idr Idris2JupyterVega/VegaLite/V5.idr
+mv v5.idr Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr
 rm v5.json

--- a/v5.sh
+++ b/v5.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-APP=$(pack app-path json-schema)
-
 wget https://vega.github.io/schema/vega-lite/v5.json
-$APP --module-name Idris2JupyterVega.VegaLite.V5 --schema-name VegaLite --json-casts v5.json
+json-schema --module-name Idris2JupyterVega.VegaLite.V5 --schema-name VegaLite --json-casts v5.json
 mv v5.idr Idris2JupyterVega/Idris2JupyterVega/VegaLite/V5.idr
 rm v5.json


### PR DESCRIPTION
This adds two minimal shell scripts and custom build hooks to the `.ipkg` file to allow Idris itself to handle the generation of the `V5.idr` source file via json-schema.

Note: I did not change the Makefile or adjust the README about the installation procedure, but theoretically, the Makefile will no longer be needed to build this library.

Note also, that pack does not yet have a way to specify dependencies on (Idris) applications managed by pack. Pack therefore cannot build this package fully automatically: The user will first have to install json-schema manually. There is work in progress to fix this. Once that's done it will be possible to add this library to pack's official package collection.